### PR TITLE
Fix singularities in `Quat::to_euler()`

### DIFF
--- a/src/f32/math.rs
+++ b/src/f32/math.rs
@@ -45,8 +45,8 @@ mod libm_math {
     }
 
     #[inline(always)]
-    pub(crate) fn asin_clamped(f: f32) -> f32 {
-        libm::asinf(f.clamp(-1.0, 1.0))
+    pub(crate) fn asin(f: f32) -> f32 {
+        libm::asinf(f)
     }
 
     #[inline(always)]
@@ -138,8 +138,8 @@ mod std_math {
     }
 
     #[inline(always)]
-    pub(crate) fn asin_clamped(f: f32) -> f32 {
-        f32::asin(f32::clamp(f, -1.0, 1.0))
+    pub(crate) fn asin(f: f32) -> f32 {
+        f32::asin(f)
     }
 
     #[inline(always)]

--- a/src/f64/math.rs
+++ b/src/f64/math.rs
@@ -11,8 +11,8 @@ mod libm_math {
     }
 
     #[inline(always)]
-    pub(crate) fn asin_clamped(f: f64) -> f64 {
-        libm::asin(f.clamp(-1.0, 1.0))
+    pub(crate) fn asin(f: f64) -> f64 {
+        libm::asin(f)
     }
 
     #[inline(always)]
@@ -103,8 +103,8 @@ mod std_math {
     }
 
     #[inline(always)]
-    pub(crate) fn asin_clamped(f: f64) -> f64 {
-        f64::asin(f64::clamp(f, -1.0, 1.0))
+    pub(crate) fn asin(f: f64) -> f64 {
+        f64::asin(f)
     }
 
     #[inline(always)]


### PR DESCRIPTION
`Quat::to_euler()` has issues when the second rotation is (near) PI/2 or -PI/2 radians, causing the first and third angles to be incorrectly calculated.

This PR addresses this issue for all supported order of rotations. It favors angles on the first axis over the third axis (e.g., a quaternion constructed from euler angles `(a, PI/2, b)` will convert back to either `(a+b, PI/2, 0)` or `(a-b, PI/2, 0)`, depending on the requested order). In any way, converting a quaternion to euler angles and back to a quaternion will always yield the original quaternion, barring any rounding errors.